### PR TITLE
Add support for different source repository/endpoint, user id mappings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source 'https://rubygems.org'
 gem "octokit", "~> 4.0"
 gem "pry"
 gem "excon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
-    coderay (1.1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
     colored (1.2)
-    excon (0.54.0)
-    faraday (0.11.0)
+    excon (0.64.0)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    method_source (0.8.2)
-    multipart-post (2.0.0)
-    octokit (4.6.2)
+    method_source (0.9.2)
+    multipart-post (2.1.1)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    pry (0.10.4)
+    pry (0.12.2)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    public_suffix (2.0.5)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
-    slop (3.6.0)
+      method_source (~> 0.9.0)
+    public_suffix (3.1.1)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
 
 PLATFORMS
   ruby
@@ -32,4 +30,4 @@ DEPENDENCIES
   pry
 
 BUNDLED WITH
-   1.13.7
+   2.0.2

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -110,7 +110,7 @@ class Hendl
         title: original.title,
         body: body.join("\n\n"),
         created_at: original.created_at.iso8601,
-        assignee: original.assignee.login, # TODO: id mapping?
+        assignee: original.assignee.nil? ? nil : original.assignee.login, # TODO: id mapping?
         labels: actual_label,
         closed: original.state != "open"
       },

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -204,16 +204,16 @@ class Hendl
   end
 end
 
-require './tools'
-destination = "fastlane/fastlane" # TODO: Should be fastlane
-names = Array(ENV["TOOL"] || @tools.delete_if { |a| a == "fastlane" }) # we don't want to import issues from our own repo
+# foo/bar, baz/qux, 'blah blah blah'
+source, destination, reason = *ARGV
+
 open_only = !ENV["ALL"]
 
-puts "Migrating #{names.join(', ')}"
+puts "Migrating #{source} -> #{destination}"
 
-names.each do |current|
-  Hendl.new(source: "fastlane/#{current}",
-       destination: destination,
-            reason: "`fastlane` is now a mono repo, you can read more about the change in our [blog post](https://krausefx.com/blog/our-goal-to-unify-fastlane-tools). All tools are now available in the [fastlane main repo](https://github.com/fastlane/fastlane) :rocket:",
-         open_only: open_only)
-end
+Hendl.new(
+  source: source,
+  destination: destination,
+  reason: resoan,
+  open_only: open_only,
+)

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -213,7 +213,7 @@ end
 # foo/bar, baz/qux, 'blah blah blah'
 source, destination, reason = *ARGV
 
-open_only = !!ENV["OPE_ONLY"].to_i
+open_only = !!ENV["OPEN_ONLY"].to_i
 
 puts "Migrating #{source} -> #{destination}"
 

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -155,7 +155,7 @@ class Hendl
       puts "closing old issue #{original.number}"
       body = []
       body << "This issue was migrated to #{new_issue_url}. Please post all further comments there."
-      body << reason
+      body << reason unless reason.nil?
       puts new_issue_url
       source_client.add_comment(source, original.number, body.join("\n\n"))
       smart_sleep
@@ -208,7 +208,7 @@ end
 # foo/bar, baz/qux, 'blah blah blah'
 source, destination, reason = *ARGV
 
-open_only = !ENV["ALL"]
+open_only = !!ENV["OPE_ONLY"].to_i
 
 puts "Migrating #{source} -> #{destination}"
 

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -72,11 +72,11 @@ class Hendl
     sleep 2.5
   end
 
-  def table(user_id, body)
+  def table(login, body)
     "<table>
       <tr>
         <td>
-          <img src='https://avatars0.githubusercontent.com/u/#{user_id}?v=3&s=70' width='35'>
+          <img src='https://github.com/#{login}.png' width='35'>
         </td>
         <td>
           #{body}
@@ -92,7 +92,7 @@ class Hendl
     comments = []
     original_comments.each do |original_comment|
       # TODO: id mapping?
-      table_code = table(original_comment.user.id, "@#{original_comment.user.login} commented")
+      table_code = table(original_comment.user.login, "@#{original_comment.user.login} commented")
       body = [table_code, original_comment.body]
       comments << {
         created_at: original_comment.created_at.iso8601,
@@ -103,7 +103,7 @@ class Hendl
     actual_label = original.labels.collect { |a| a[:name] }
 
     table_link = "Imported from <a href='#{original.html_url}'>#{source}##{original.number}</a>"
-    table_code = table(original.user.id, "Original issue by @#{original.user.login} - #{table_link}")
+    table_code = table(original.user.login, "Original issue by @#{original.user.login} - #{table_link}")
     body = [table_code, original.body]
     data = {
       issue: {

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -91,6 +91,7 @@ class Hendl
     original_comments = source_client.issue_comments(source, original.number)
     comments = []
     original_comments.each do |original_comment|
+      # TODO: id mapping?
       table_code = table(original_comment.user.id, "@#{original_comment.user.login} commented")
       body = [table_code, original_comment.body]
       comments << {
@@ -109,7 +110,7 @@ class Hendl
         title: original.title,
         body: body.join("\n\n"),
         created_at: original.created_at.iso8601,
-        assignee: original.assignee.login,
+        assignee: original.assignee.login, # TODO: id mapping?
         labels: actual_label,
         closed: original.state != "open"
       },

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -24,11 +24,10 @@ class Hendl
   end
 
   def source_client
-    @source_client ||= Octokit::Client.new(access_token: ENV["SOURCE_GITHUB_API_TOKEN"])
-  end
-
-  def destination_client
-    @destination_client ||= Octokit::Client.new(access_token: ENV["DESTINATION_GITHUB_API_TOKEN"])
+    @source_client ||= Octokit::Client.new(
+      access_token: ENV["SOURCE_GITHUB_API_TOKEN"],
+      api_endpoint: ENV.fetch("SOURCE_GITHUB_API_ENDPOINT", Octokit.api_endpoint),
+    )
   end
 
   def start

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -215,6 +215,6 @@ puts "Migrating #{source} -> #{destination}"
 Hendl.new(
   source: source,
   destination: destination,
-  reason: resoan,
+  reason: reason,
   open_only: open_only,
 )

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -109,6 +109,7 @@ class Hendl
         title: original.title,
         body: body.join("\n\n"),
         created_at: original.created_at.iso8601,
+        assignee: original.assignee.login,
         labels: actual_label,
         closed: original.state != "open"
       },

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -127,7 +127,7 @@ class Hendl
     }
     data[:issue][:closed_at] = original.closed_at.iso8601 if original.state != "open"
 
-    response = Excon.post("https://api.github.com/repos/#{destination}/import/issues", body: data.to_json, headers: destination_request_headers)
+    response = Excon.post("https://api.github.com/repos/#{destination}/import/issues", body: data.to_json, headers: request_headers)
     response = JSON.parse(response.body)
     status_url = response['url']
     puts response
@@ -139,7 +139,7 @@ class Hendl
         sleep(request_num)
 
         puts "Sending #{status_url}"
-        async_response = Excon.get(status_url, headers: destination_request_headers) # if this crashes, make sure to have a valid token with admin permission to the actual repo
+        async_response = Excon.get(status_url, headers: request_headers) # if this crashes, make sure to have a valid token with admin permission to the actual repo
         async_response = JSON.parse(async_response.body)
         puts async_response.to_s.yellow
 
@@ -178,18 +178,10 @@ class Hendl
     end
   end
 
-  def source_request_headers
-    request_headers(ENV["SOURCE_GITHUB_API_TOKEN"])
-  end
-
-  def destination_request_headers
-    request_headers(ENV["DESTINATION_GITHUB_API_TOKEN"])
-  end
-
-  def request_headers(token)
+  def request_headers
     {
       "Accept" => "application/vnd.github.golden-comet-preview+json",
-      "Authorization" => ("token " + token),
+      "Authorization" => ("token " + ENV["DESTINATION_GITHUB_API_TOKEN"]),
       "Content-Type" => "application/x-www-form-urlencoded",
       "User-Agent" => "fastlane bot"
     }

--- a/migrate_issues.rb
+++ b/migrate_issues.rb
@@ -120,7 +120,7 @@ class Hendl
         body: body.join("\n\n"),
         created_at: original.created_at.iso8601,
         assignee: original.assignee.nil? ? nil : map_login_id(original.assignee.login),
-        labels: actual_label,
+        labels: actual_label + ["imported"],
         closed: original.state != "open"
       },
       comments: comments


### PR DESCRIPTION
We wanna migrate issues from GitHub Enterprise to github.com, so add support for set different access_token, endpoint and user id mappings.